### PR TITLE
feat: add thumbnail

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,5 +38,6 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@next/next/no-img-element': 'off',
   },
 }

--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -21,17 +21,20 @@ export default function Home({ posts }) {
         <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {!posts.length && 'No posts found.'}
           {posts.slice(0, MAX_DISPLAY).map((post) => {
-            const { slug, date, title, summary, tags } = post
+            const { slug, date, title, summary, tags, images: [img] = [] } = post
             return (
               <li key={slug} className="py-12">
                 <article>
-                  <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
-                    <dl>
-                      <dt className="sr-only">Published on</dt>
-                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                        <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
-                      </dd>
-                    </dl>
+                  <div className="space-y-2 grid xl:grid-cols-4 xl:items-baseline xl:space-y-0 gap-4">
+                    <div className="grid gap-4">
+                      <dl>
+                        <dt className="sr-only">Published on</dt>
+                        <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                          <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
+                        </dd>
+                      </dl>
+                      {img && <img src={img} alt="" className="w-full max-w-xs" />}
+                    </div>
                     <div className="space-y-5 xl:col-span-3">
                       <div className="space-y-6">
                         <div>

--- a/data/blog/2023/alamoa-blog-start.mdx
+++ b/data/blog/2023/alamoa-blog-start.mdx
@@ -5,7 +5,7 @@ lastmod: '2023-10-01'
 tags: ['お知らせ']
 draft: false
 summary: 'この度、「alamoa」は、IT系エンジニア教育に特化したブログサイトを開設いたしました。'
-images: []
+images: ['/static/images/projects/alamoa.png']
 authors: ['jsakai']
 ---
 

--- a/data/blog/2023/release-qd-pocket.mdx
+++ b/data/blog/2023/release-qd-pocket.mdx
@@ -5,6 +5,7 @@ lastmod: '2023-11-01'
 tags: ['お知らせ']
 draft: false
 summary: 'この度、「alamoa」は、インフルエンサーになんでも質問できるQD pocketをリリースしました'
+images: ['/static/images/projects/qdpocket.png']
 authors: ['jsakai']
 ---
 


### PR DESCRIPTION
## Description

This blog already has a feature to add thumbnail with `images` content prop using [Contentlayer](https://www.contentlayer.dev/).

https://github.com/alamoa-io/blog#post

Using the `images` prop, add it as a thumbnail on the landing page.

## Preview

Original: https://blog.alamoa.io/
Preview: https://blog-git-feature-add-thumbnail-alamoa.vercel.app/
Dev: http://localhost:3000/

## Screenshot

||Before|After|
|--|--|--|
|Mobile|<img width="180" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/595585cc-09ce-40bf-9437-8b5c1390e5b2">|<img width="180" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/a655724f-17a9-416f-a165-962753533f1f">|
|Tablet|<img width="300" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/355d852b-4899-47dc-8e0d-ccf8caa7e553">|<img width="300" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/2a15aa77-b9d3-4b32-a94b-65bfa15b5bcd">|
|Desktop|<img width="450" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/0cd13d7d-fc18-450f-894e-9a1b9373ac76">|<img width="450" alt="image" src="https://github.com/alamoa-io/blog/assets/588874/a8123da7-50b7-4135-bb3d-d1dfa1e5e818">|
